### PR TITLE
Fix the `env` method on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ module.exports.env = opts => {
 		env: Object.assign({}, process.env)
 	}, opts);
 
-	const path = pathKey();
 	const env = opts.env;
+	const path = pathKey({env});
 
 	opts.path = env[path];
 	env[path] = module.exports(opts);


### PR DESCRIPTION
The tests fail on Windows without this change. Also `grunt-shell` sometimes doesn't work as expected because of this.