### PR TITLE
Avoid including node binary path if it already presented

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,11 @@ module.exports = opts => {
 	}
 
 	// ensure the running `node` binary is used
-	ret.push(path.dirname(process.execPath));
+	const binNodePth = path.dirname(process.execPath)
+	const testExisting = new RegExp(`:${binNodePth}:`)
+	if(!testExisting.test(opts.path)) {
+		ret.push(binNodePth);
+	}
 
 	return ret.concat(opts.path).join(path.delimiter);
 };

--- a/index.js
+++ b/index.js
@@ -19,9 +19,9 @@ module.exports = opts => {
 	}
 
 	// ensure the running `node` binary is used
-	const binNodePth = path.dirname(process.execPath)
-	const testExisting = new RegExp(`:${binNodePth}:`)
-	if(!testExisting.test(opts.path)) {
+	const binNodePth = path.dirname(process.execPath);
+	const testExisting = new RegExp(`:${binNodePth}:`);
+	if (!testExisting.test(opts.path)) {
 		ret.push(binNodePth);
 	}
 


### PR DESCRIPTION
To preventing override user order in PATH(which used in version managers, example, rvm(ruby version manager))