### PR TITLE
Fix repeated `execPath` directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@ const npmRunPath = options => {
 // Ensure the running `node` binary is used.
 // Noop if the directory is already in `PATH`
 const getExecDir = function (options) {
-	const execDir = path.dirname(process.execPath);
-	return options.path.split(path.delimiter).some(inputPath => inputPath === execDir) ?
+	const execDir = path.normalize(path.dirname(process.execPath));
+	return options.path.split(path.delimiter).some(inputPath => path.normalize(inputPath) === execDir) ?
 		[] :
 		[execDir];
 };

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ const npmRunPath = options => {
 
 	const execDir = getExecDir(options);
 
-	return result.concat(execDir).concat(options.path).join(path.delimiter);
+	return result.concat(execDir, options.path).join(path.delimiter);
 };
 
 // Ensure the running `node` binary is used.

--- a/index.js
+++ b/index.js
@@ -19,10 +19,18 @@ const npmRunPath = options => {
 		cwdPath = path.resolve(cwdPath, '..');
 	}
 
-	// Ensure the running `node` binary is used
-	result.push(path.dirname(process.execPath));
+	const execDir = getExecDir(options);
 
-	return result.concat(options.path).join(path.delimiter);
+	return result.concat(execDir).concat(options.path).join(path.delimiter);
+};
+
+// Ensure the running `node` binary is used.
+// Noop if the directory is already in `PATH`
+const getExecDir = function (options) {
+	const execDir = path.dirname(process.execPath);
+	return options.path.split(path.delimiter).some(inputPath => inputPath === execDir) ?
+		[] :
+		[execDir];
 };
 
 module.exports = npmRunPath;

--- a/test.js
+++ b/test.js
@@ -13,3 +13,10 @@ test('main', t => {
 		path.join(__dirname, 'node_modules/.bin')
 	);
 });
+
+test('does not repeat execPath directory', t => {
+	const execDir = path.dirname(process.execPath);
+	const result = npmRunPath({path: execDir});
+	const execDirs = result.split(path.delimiter).filter(resultPath => resultPath === execDir);
+	t.is(execDirs.length, 1);
+});

--- a/test.js
+++ b/test.js
@@ -20,3 +20,10 @@ test('does not repeat execPath directory', t => {
 	const execDirs = result.split(path.delimiter).filter(resultPath => resultPath === execDir);
 	t.is(execDirs.length, 1);
 });
+
+test('does not repeat execPath directory even when using a different form', t => {
+	const execDir = `${path.dirname(process.execPath)}/.`;
+	const result = npmRunPath({path: execDir});
+	const execDirs = result.split(path.delimiter).filter(resultPath => path.normalize(resultPath) === path.normalize(execDir));
+	t.is(execDirs.length, 1);
+});


### PR DESCRIPTION
This is another implementation for #3 since that PR became stale and does not include tests.

This might solve the following issues on `execa`: 
  - https://github.com/sindresorhus/execa/issues/153 
  - https://github.com/sindresorhus/execa/issues/196

`npm-run-path` unshifts `dirname(process.execPath)` to the `$PATH`. From my understanding (correct me if I'm wrong) the reason is this:
  - a user might have several versions of `node` installed
  - a specific version of `node` different from the default one (i.e. not in `$PATH`) might be the one currently running
  - we want to ensure if `node` gets called in a child process, the same Node version will be used.
  - arguably we also want globally installed binaries to be the ones installed under that Node version.

Now I am wondering how this would happen in practice. For example, `nvm use` and `nvm exec` correctly modify the `$PATH`, so this is not a problem with `nvm`. @sindresorhus maybe you have more information on why this is needed?

Now the problem is that this conflicts with other tools that are competing for priority in the `$PATH`. 

I am not sure whether firing the right `node` version or giving priority to those other tools is a decidable problem with an objective solution? But at least what we could do is not do anything if `dirname(process.execPath)` is already present in the `$PATH`, which this PR implements. 

Current limitation: this does not work if `dirname(process.execPath)` is symlinked and referenced under different symlink names under both the `$PATH` and `process.execPath`. This is harder to fix since the current code is synchronous and relies on `path.*()` not `fs.*()`.