### PR TITLE
Give `execPath` a higher priority than local binaries

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const npmRunPath = options => {
 	}
 
 	// Ensure the running `node` binary is used
-	result.push(path.dirname(process.execPath));
+	result.unshift(path.dirname(process.execPath));
 
 	return result.concat(options.path).join(path.delimiter);
 };

--- a/test.js
+++ b/test.js
@@ -4,12 +4,19 @@ import npmRunPath from '.';
 
 test('main', t => {
 	t.is(
-		npmRunPath({path: ''}).split(path.delimiter)[0],
+		npmRunPath({path: ''}).split(path.delimiter)[1],
 		path.join(__dirname, 'node_modules/.bin')
 	);
 
 	t.is(
-		npmRunPath.env({env: {PATH: 'foo'}}).PATH.split(path.delimiter)[0],
+		npmRunPath.env({env: {PATH: 'foo'}}).PATH.split(path.delimiter)[1],
 		path.join(__dirname, 'node_modules/.bin')
+	);
+});
+
+test('Push execPath to the front of the PATH', t => {
+	t.is(
+		npmRunPath({path: ''}).split(path.delimiter)[0],
+		path.dirname(process.execPath)
 	);
 });

--- a/test.js
+++ b/test.js
@@ -14,7 +14,7 @@ test('main', t => {
 	);
 });
 
-test('Push execPath to the front of the PATH', t => {
+test('push `execPath` to the front of the PATH', t => {
 	t.is(
 		npmRunPath({path: ''}).split(path.delimiter)[0],
 		path.dirname(process.execPath)


### PR DESCRIPTION
[`npx node`](https://github.com/aredridel/node-bin-gen/blob/master/node-bin-README.md#use-with-npx) is a way to run a command with a specific Node.js version. For example `npx node@8.0.0 npm test`. It installs the Node.js package called [`node`](https://www.npmjs.com/package/node) maintained by some npm core contributors.

For this reason it is possible for the `node` binary to be installed inside `node_modules/.bin/`. If a user has previously run `npx node@8`, then later on uses `npm-run-path`, `node@8` will be used regardless of what `process.execPath` is. 

This PR fixes this by giving `execPath` a higher priority than local binaries.