### PR TITLE
Add `execPath` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,9 @@ declare namespace npmRunPath {
 		readonly path?: string;
 
 		/**
-		Path to the current Node.js executable. Its directory is pushed to the front of PATH.
+		Path to the Node.js executable to use in child processes if that is different from the current one. Its directory is pushed to the front of PATH.
+
+		This can be either an absolute path or a path relative to the `cwd` option.
 
 		@default process.execPath
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,13 @@ declare namespace npmRunPath {
 		Set it to an empty string to exclude the default PATH.
 		*/
 		readonly path?: string;
+
+		/**
+		Path to the current Node.js executable. Its directory is pushed to the front of PATH.
+
+		@default process.execPath
+		*/
+		readonly execPath?: string;
 	}
 
 	interface ProcessEnv {
@@ -31,6 +38,13 @@ declare namespace npmRunPath {
 		Accepts an object of environment variables, like `process.env`, and modifies the PATH using the correct [PATH key](https://github.com/sindresorhus/path-key). Use this if you're modifying the PATH for use in the `child_process` options.
 		*/
 		readonly env?: ProcessEnv;
+
+		/**
+		Path to the current Node.js executable. Its directory is pushed to the front of PATH.
+
+		@default process.execPath
+		*/
+		readonly execPath?: string;
 	}
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,8 @@ declare namespace npmRunPath {
 		/**
 		Path to the current Node.js executable. Its directory is pushed to the front of PATH.
 
+		This can be either an absolute path or a path relative to the `cwd` option.
+
 		@default process.execPath
 		*/
 		readonly execPath?: string;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const npmRunPath = options => {
 	options = {
 		cwd: process.cwd(),
 		path: process.env[pathKey()],
+		execPath: process.execPath,
 		...options
 	};
 
@@ -20,7 +21,8 @@ const npmRunPath = options => {
 	}
 
 	// Ensure the running `node` binary is used
-	result.unshift(path.dirname(process.execPath));
+	const execPathDir = path.resolve(options.cwd, options.execPath, '..');
+	result.unshift(execPathDir);
 
 	return result.concat(options.path).join(path.delimiter);
 };

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -5,7 +5,9 @@ import {ProcessEnv} from '.';
 expectType<string>(npmRunPath());
 expectType<string>(npmRunPath({cwd: '/foo'}));
 expectType<string>(npmRunPath({path: '/usr/local/bin'}));
+expectType<string>(npmRunPath({execPath: '/usr/local/bin'}));
 
 expectType<ProcessEnv>(npmRunPath.env());
 expectType<ProcessEnv>(npmRunPath.env({cwd: '/foo'}));
 expectType<ProcessEnv>(npmRunPath.env({env: process.env}));
+expectType<ProcessEnv>(npmRunPath.env({execPath: '/usr/local/bin'}));

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,13 @@ Default: [`PATH`](https://github.com/sindresorhus/path-key)
 PATH to be appended.<br>
 Set it to an empty string to exclude the default PATH.
 
+##### execPath
+
+Type: `string`<br>
+Default: `process.execPath`
+
+Path to the current Node.js executable. Its directory is pushed to the front of PATH.
+
 ### npmRunPath.env(options?)
 
 Returns the augmented [`process.env`](https://nodejs.org/api/process.html#process_process_env) object.
@@ -76,6 +83,13 @@ Working directory.
 Type: `Object`
 
 Accepts an object of environment variables, like `process.env`, and modifies the PATH using the correct [PATH key](https://github.com/sindresorhus/path-key). Use this if you're modifying the PATH for use in the `child_process` options.
+
+##### execPath
+
+Type: `string`<br>
+Default: `process.execPath`
+
+Path to the current Node.js executable. Its directory is pushed to the front of PATH.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -63,6 +63,8 @@ Default: `process.execPath`
 
 Path to the current Node.js executable. Its directory is pushed to the front of PATH.
 
+This can be either an absolute path or a path relative to the `cwd` option.
+
 ### npmRunPath.env(options?)
 
 Returns the augmented [`process.env`](https://nodejs.org/api/process.html#process_process_env) object.

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Default: `process.execPath`
 
 Path to the current Node.js executable. Its directory is pushed to the front of PATH.
 
-This can be either an absolute path or a path relative to the `cwd` option.
+This can be either an absolute path or a path relative to the [`cwd` option](#cwd).
 
 ### npmRunPath.env(options?)
 

--- a/readme.md
+++ b/readme.md
@@ -89,7 +89,9 @@ Accepts an object of environment variables, like `process.env`, and modifies the
 Type: `string`<br>
 Default: `process.execPath`
 
-Path to the current Node.js executable. Its directory is pushed to the front of PATH.
+Path to the Node.js executable to use in child processes if that is different from the current one. Its directory is pushed to the front of PATH.
+
+This can be either an absolute path or a path relative to the [`cwd` option](#cwd).
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -21,14 +21,14 @@ test('push `execPath` to the front of the PATH', t => {
 	);
 });
 
-test('Can change execPath with the execPath option', t => {
+test('can change `execPath` with the `execPath` option', t => {
 	t.is(
 		npmRunPath({path: '', execPath: 'test/test'}).split(path.delimiter)[0],
 		path.resolve(process.cwd(), 'test')
 	);
 });
 
-test('The execPath option is relative to the cwd option', t => {
+test('the `execPath` option is relative to the `cwd` option', t => {
 	t.is(
 		npmRunPath({path: '', execPath: 'test/test', cwd: '/dir'}).split(path.delimiter)[0],
 		path.normalize('/dir/test')

--- a/test.js
+++ b/test.js
@@ -20,3 +20,17 @@ test('push `execPath` to the front of the PATH', t => {
 		path.dirname(process.execPath)
 	);
 });
+
+test('Can change execPath with the execPath option', t => {
+	t.is(
+		npmRunPath({path: '', execPath: 'test/test'}).split(path.delimiter)[0],
+		path.resolve(process.cwd(), 'test')
+	);
+});
+
+test('The execPath option is relative to the cwd option', t => {
+	t.is(
+		npmRunPath({path: '', execPath: 'test/test', cwd: '/dir'}).split(path.delimiter)[0],
+		path.normalize('/dir/test')
+	);
+});


### PR DESCRIPTION
This is a follow up on #5. Also related: https://github.com/sindresorhus/execa/issues/153 and https://github.com/sindresorhus/execa/issues/196.

There are some cases where users might want a different `execPath` than the current one to be used. This PR gives them that option. It defaults to `process.execPath` so the default behavior does not change.

`execPath` can be either an absolute path or a path relative to `options.cwd`.