### PR TITLE
Local binaries should have higher priority than global binaries

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const npmRunPath = options => {
 
 	// Ensure the running `node` binary is used
 	const execPathDir = path.resolve(options.cwd, options.execPath, '..');
-	result.unshift(execPathDir);
+	result.push(execPathDir);
 
 	return result.concat(options.path).join(path.delimiter);
 };

--- a/test.js
+++ b/test.js
@@ -4,33 +4,33 @@ import npmRunPath from '.';
 
 test('main', t => {
 	t.is(
-		npmRunPath({path: ''}).split(path.delimiter)[1],
+		npmRunPath({path: ''}).split(path.delimiter)[0],
 		path.join(__dirname, 'node_modules/.bin')
 	);
 
 	t.is(
-		npmRunPath.env({env: {PATH: 'foo'}}).PATH.split(path.delimiter)[1],
+		npmRunPath.env({env: {PATH: 'foo'}}).PATH.split(path.delimiter)[0],
 		path.join(__dirname, 'node_modules/.bin')
 	);
 });
 
-test('push `execPath` to the front of the PATH', t => {
-	t.is(
-		npmRunPath({path: ''}).split(path.delimiter)[0],
-		path.dirname(process.execPath)
-	);
+test('push `execPath` later in the PATH', t => {
+	const pathEnv = npmRunPath({path: ''}).split(path.delimiter);
+	t.is(pathEnv[pathEnv.length - 2], path.dirname(process.execPath));
 });
 
 test('can change `execPath` with the `execPath` option', t => {
-	t.is(
-		npmRunPath({path: '', execPath: 'test/test'}).split(path.delimiter)[0],
-		path.resolve(process.cwd(), 'test')
+	const pathEnv = npmRunPath({path: '', execPath: 'test/test'}).split(
+		path.delimiter
 	);
+	t.is(pathEnv[pathEnv.length - 2], path.resolve(process.cwd(), 'test'));
 });
 
 test('the `execPath` option is relative to the `cwd` option', t => {
-	t.is(
-		npmRunPath({path: '', execPath: 'test/test', cwd: '/dir'}).split(path.delimiter)[0],
-		path.normalize('/dir/test')
-	);
+	const pathEnv = npmRunPath({
+		path: '',
+		execPath: 'test/test',
+		cwd: '/dir'
+	}).split(path.delimiter);
+	t.is(pathEnv[pathEnv.length - 2], path.normalize('/dir/test'));
 });


### PR DESCRIPTION
Currently `npm-run-path` makes global binaries have higher priority than local binaries, which is incorrect. 

This bug was introduced by me in #8 (I am very sorry about this! :-/ ). The reason behind #8 was for `npm-run-path` to enforce that the current Node.js version is re-used in child processes, including when a user installs `node` locally (e.g. through `npx node`).

However, as a side effect, #8 also inverted the priority between global binaries and local binaries since `node` is installed in the same directory as binaries. This means Execa `preferLocal` option is no longer working (see https://github.com/sindresorhus/execa/issues/404).

This PR reverts to the old behavior.