### PR TITLE
Allow `cwd` option to be a `URL`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ export interface RunPathOptions {
 
 	@default process.cwd()
 	*/
-	readonly cwd?: string;
+	readonly cwd?: string | URL;
 
 	/**
 	PATH to be appended. Default: [`PATH`](https://github.com/sindresorhus/path-key).
@@ -31,7 +31,7 @@ export interface EnvOptions {
 
 	@default process.cwd()
 	*/
-	readonly cwd?: string;
+	readonly cwd?: string | URL;
 
 	/**
 	Accepts an object of environment variables, like `process.env`, and modifies the PATH using the correct [PATH key](https://github.com/sindresorhus/path-key). Use this if you're modifying the PATH for use in the `child_process` options.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 import process from 'node:process';
 import path from 'node:path';
+import url from 'node:url';
 import pathKey from 'path-key';
 
 export function npmRunPath(options = {}) {
@@ -10,7 +11,8 @@ export function npmRunPath(options = {}) {
 	} = options;
 
 	let previous;
-	let cwdPath = path.resolve(cwd);
+	const cwdString = cwd instanceof URL ? url.fileURLToPath(cwd) : cwd;
+	let cwdPath = path.resolve(cwdString);
 	const result = [];
 
 	while (previous !== cwdPath) {
@@ -20,7 +22,7 @@ export function npmRunPath(options = {}) {
 	}
 
 	// Ensure the running `node` binary is used.
-	result.push(path.resolve(cwd, execPath, '..'));
+	result.push(path.resolve(cwdString, execPath, '..'));
 
 	return [...result, path_].join(path.delimiter);
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,10 +4,12 @@ import {npmRunPath, npmRunPathEnv, ProcessEnv} from './index.js';
 
 expectType<string>(npmRunPath());
 expectType<string>(npmRunPath({cwd: '/foo'}));
+expectType<string>(npmRunPath({cwd: new URL('file:///foo')}));
 expectType<string>(npmRunPath({path: '/usr/local/bin'}));
 expectType<string>(npmRunPath({execPath: '/usr/local/bin'}));
 
 expectType<ProcessEnv>(npmRunPathEnv());
 expectType<ProcessEnv>(npmRunPathEnv({cwd: '/foo'}));
+expectType<ProcessEnv>(npmRunPathEnv({cwd: new URL('file:///foo')}));
 expectType<ProcessEnv>(npmRunPathEnv({env: process.env})); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
 expectType<ProcessEnv>(npmRunPathEnv({execPath: '/usr/local/bin'}));

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Type: `object`
 
 ##### cwd
 
-Type: `string`\
+Type: `string | URL`\
 Default: `process.cwd()`
 
 The working directory.
@@ -73,7 +73,7 @@ Type: `object`
 
 ##### cwd
 
-Type: `string`\
+Type: `string | URL`\
 Default: `process.cwd()`
 
 The working directory.

--- a/test.js
+++ b/test.js
@@ -18,6 +18,20 @@ test('main', t => {
 	);
 });
 
+test('the `cwd` option changes the current directory', t => {
+	t.is(
+		npmRunPath({path: '', cwd: '/dir'}).split(path.delimiter)[0],
+		path.normalize('/dir/node_modules/.bin'),
+	);
+});
+
+test('the `cwd` option can be a file URL', t => {
+	t.is(
+		npmRunPath({path: '', cwd: new URL('file:///dir')}).split(path.delimiter)[0],
+		path.normalize('/dir/node_modules/.bin'),
+	);
+});
+
 test('push `execPath` later in the PATH', t => {
 	const pathEnv = npmRunPath({path: ''}).split(path.delimiter);
 	t.is(pathEnv[pathEnv.length - 2], path.dirname(process.execPath));


### PR DESCRIPTION
Fixes https://github.com/sindresorhus/npm-run-path/issues/14

This adds the possibility for the `cwd` option to be a `URL`.