### PR TITLE
Allow `execPath` to be a file URL

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,7 @@ export interface RunPathOptions {
 
 	@default process.execPath
 	*/
-	readonly execPath?: string;
+	readonly execPath?: string | URL;
 }
 
 export type ProcessEnv = Record<string, string | undefined>;
@@ -45,7 +45,7 @@ export interface EnvOptions {
 
 	@default process.execPath
 	*/
-	readonly execPath?: string;
+	readonly execPath?: string | URL;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ export function npmRunPath(options = {}) {
 	} = options;
 
 	let previous;
+	const execPathString = execPath instanceof URL ? url.fileURLToPath(execPath) : execPath;
 	const cwdString = cwd instanceof URL ? url.fileURLToPath(cwd) : cwd;
 	let cwdPath = path.resolve(cwdString);
 	const result = [];
@@ -22,7 +23,7 @@ export function npmRunPath(options = {}) {
 	}
 
 	// Ensure the running `node` binary is used.
-	result.push(path.resolve(cwdString, execPath, '..'));
+	result.push(path.resolve(cwdString, execPathString, '..'));
 
 	return [...result, path_].join(path.delimiter);
 }

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -7,9 +7,11 @@ expectType<string>(npmRunPath({cwd: '/foo'}));
 expectType<string>(npmRunPath({cwd: new URL('file:///foo')}));
 expectType<string>(npmRunPath({path: '/usr/local/bin'}));
 expectType<string>(npmRunPath({execPath: '/usr/local/bin'}));
+expectType<string>(npmRunPath({execPath: new URL('file:///usr/local/bin')}));
 
 expectType<ProcessEnv>(npmRunPathEnv());
 expectType<ProcessEnv>(npmRunPathEnv({cwd: '/foo'}));
 expectType<ProcessEnv>(npmRunPathEnv({cwd: new URL('file:///foo')}));
 expectType<ProcessEnv>(npmRunPathEnv({env: process.env})); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
 expectType<ProcessEnv>(npmRunPathEnv({execPath: '/usr/local/bin'}));
+expectType<ProcessEnv>(npmRunPathEnv({execPath: new URL('file:///usr/local/bin')}));

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ Set it to an empty string to exclude the default PATH.
 
 ##### execPath
 
-Type: `string`\
+Type: `string | URL`\
 Default: `process.execPath`
 
 The path to the current Node.js executable. Its directory is pushed to the front of PATH.

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 import process from 'node:process';
 import path from 'node:path';
-import {fileURLToPath} from 'node:url';
+import {fileURLToPath, pathToFileURL} from 'node:url';
 import test from 'ava';
 import {npmRunPath, npmRunPathEnv} from './index.js';
 
@@ -44,6 +44,13 @@ test('can change `execPath` with the `execPath` option', t => {
 	t.is(pathEnv[pathEnv.length - 2], path.resolve(process.cwd(), 'test'));
 });
 
+test('the `execPath` option can be a file URL', t => {
+	const pathEnv = npmRunPath({path: '', execPath: pathToFileURL('test/test')}).split(
+		path.delimiter,
+	);
+	t.is(pathEnv[pathEnv.length - 2], path.resolve(process.cwd(), 'test'));
+});
+
 test('the `execPath` option is relative to the `cwd` option', t => {
 	const pathEnv = npmRunPath({
 		path: '',
@@ -52,3 +59,4 @@ test('the `execPath` option is relative to the `cwd` option', t => {
 	}).split(path.delimiter);
 	t.is(pathEnv[pathEnv.length - 2], path.normalize('/dir/test'));
 });
+

--- a/test.js
+++ b/test.js
@@ -59,4 +59,3 @@ test('the `execPath` option is relative to the `cwd` option', t => {
 	}).split(path.delimiter);
 	t.is(pathEnv[pathEnv.length - 2], path.normalize('/dir/test'));
 });
-


### PR DESCRIPTION
Part of https://github.com/sindresorhus/execa/issues/458

This allows `execPath` to be a file URL.