### PR TITLE
Run tests on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,14 +4,18 @@ on:
   - pull_request
 jobs:
   test:
-    name: Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         node-version:
           - 22
           - 18
+        os:
+          - ubuntu
+          - macos
+          - windows
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/test.js
+++ b/test.js
@@ -32,15 +32,15 @@ test('"preferLocal: false", "addExecPath: false" does not add node_modules/.bin 
 
 test('the `cwd` option changes the current directory', t => {
 	t.is(
-		npmRunPath({path: '', cwd: '/dir'}).split(path.delimiter)[0],
-		path.normalize('/dir/node_modules/.bin'),
+		npmRunPath({path: '', cwd: './dir'}).split(path.delimiter)[0],
+		path.resolve('./dir/node_modules/.bin'),
 	);
 });
 
 test('the `cwd` option can be a file URL', t => {
 	t.is(
-		npmRunPath({path: '', cwd: new URL('file:///dir')}).split(path.delimiter)[0],
-		path.normalize('/dir/node_modules/.bin'),
+		npmRunPath({path: '', cwd: new URL('dir', import.meta.url)}).split(path.delimiter)[0],
+		fileURLToPath(new URL('dir/node_modules/.bin', import.meta.url)),
 	);
 });
 
@@ -88,7 +88,7 @@ test('the `execPath` option is relative to the `cwd` option', t => {
 	const pathEnv = npmRunPath({
 		path: '',
 		execPath: 'test/test',
-		cwd: '/dir',
+		cwd: './dir',
 	}).split(path.delimiter);
-	t.is(pathEnv.at(-2), path.normalize('/dir/test'));
+	t.is(pathEnv.at(-2), path.resolve('./dir/test'));
 });


### PR DESCRIPTION
This PR adds testing on Windows.

This module includes a few bits that is OS-specific: `PATH` vs `Path` key, `PATH` delimiter `;` vs `:`, how file URLs are handled, and file path resolution in general (e.g. hard drive letters). So it might make sense to test on Windows as well.